### PR TITLE
Update static web app CORS origin

### DIFF
--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -20,7 +20,7 @@
     "cors": {
       "allowedOrigins": [
         "https://tuttiud.thepcrunners.com",
-        "https://green-dune-05f6e103.westeurope.1.azurestaticapps.net"
+        "https://lemon-wave-0e6c61303.westeurope.1.azurestaticapps.net"
       ]
     }
   }


### PR DESCRIPTION
## Summary
- replace the old Azure Static Web App allowed origin with the new lemon-wave domain in the static web app configuration

## Testing
- `npm run build`
- `npx eslint .` *(fails: pre-existing Fast Refresh export and lint errors in badge.jsx, button.jsx, sidebar.jsx, api-client.js, layoutSwap.js, OrgContext.jsx, tailwind.config.js, tmp_TimeEntryTable.jsx, and vite.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68f8097c3c088330b0faedfc4d825583