### PR TITLE
Support optional intake approval notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1097,6 +1097,7 @@
 - **API endpoints**:
   - `POST /api/intake` is public (Power Automate) and requires `x-org-id` plus `x-intake-secret` before inserting/updating student intake data. The request provides `html_content` which is parsed into Hebrew question/answer pairs.
   - `POST /api/intake/approve` requires Supabase auth; admins can approve any student, members only their assigned students. Updates `needs_intake_approval=false`, appends `metadata.last_approval`, and stores agreement metadata under `metadata.last_approval.agreement`.
+    - Optional approval notes can be sent; if present they are prepended to `Students.notes` wrapped between separator lines and the label "הערות קליטה" (existing notes are preserved below).
 - **Frontend**:
   - `IntakeSettingsCard.jsx` in Settings allows admins to manage mappings and rotate secrets.
   - `IntakeReviewQueue.jsx` on the dashboard surfaces pending intake approvals, keeps student cards collapsed by default, and requires an agreement confirmation before calling `/api/intake/approve`.

--- a/api/intake-approve/index.js
+++ b/api/intake-approve/index.js
@@ -73,12 +73,13 @@ function buildAgreementPayload(raw, userId) {
 
 const INTAKE_NOTES_SEPARATOR = '------------------------------------';
 
-function buildIntakeNotesBlock(raw) {
+function buildIntakeNotesBlock(raw, dateStr) {
   const note = normalizeString(raw);
   if (!note) {
     return null;
   }
-  return `${INTAKE_NOTES_SEPARATOR}\nהערות קליטה:\n${note}\n${INTAKE_NOTES_SEPARATOR}`;
+  const dateLabel = dateStr ? ` (${dateStr})` : '';
+  return `${INTAKE_NOTES_SEPARATOR}\nהערות קליטה${dateLabel}:\n${note}\n${INTAKE_NOTES_SEPARATOR}`;
 }
 
 export default async function handler(context, req) {
@@ -180,7 +181,8 @@ export default async function handler(context, req) {
   }
 
   const intakeNotesBlock = buildIntakeNotesBlock(
-    body?.approval_notes || body?.intake_notes || body?.notes
+    body?.approval_notes || body?.intake_notes || body?.notes,
+    body?.approval_date
   );
   const existingNotes = normalizeString(student?.notes);
   const updatedNotes = intakeNotesBlock

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tuttiud-api",
   "type": "module",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "private": true,
   "engines": {
     "node": ">=18 <20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tuttiud-app",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tuttiud-app",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Shaked Yossef",
   "main": "electron.cjs",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.9.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ChangelogModal.jsx
+++ b/src/components/ChangelogModal.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 export default function ChangelogModal({ open, onClose }) {
   // הגרסה האחרונה נפתחת כברירת מחדל
-  const [expandedVersions, setExpandedVersions] = useState({ '1.9.2': true });
+  const [expandedVersions, setExpandedVersions] = useState({ '1.9.3': true });
 
   const toggleVersion = (version) => {
     setExpandedVersions(prev => ({
@@ -89,6 +89,67 @@ export default function ChangelogModal({ open, onClose }) {
 
         <div style={{ padding: '24px', overflowY: 'auto', flex: 1 }}>
         <ul style={{ listStyle: 'none', padding: 0, margin: 0, color: '#334155', fontSize: 15, lineHeight: 1.7 }}>
+
+          {/* 1.9.3 - Intake Notes */}
+          <li dir="rtl" style={{ marginBottom: 16, textAlign: 'right' }}>
+            <article style={{ display: 'flex', flexDirection: 'column' }}>
+              <header
+                onClick={() => toggleVersion('1.9.3')}
+                style={{
+                  cursor: 'pointer',
+                  padding: '12px 16px',
+                  borderRadius: '8px',
+                  background: expandedVersions['1.9.3'] ? '#f8fafc' : 'transparent',
+                  border: '1px solid #e2e8f0',
+                  transition: 'all 0.2s ease',
+                  marginBottom: expandedVersions['1.9.3'] ? '16px' : 0
+                }}
+              >
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+                    <span style={{
+                      background: '#5B5BD6',
+                      color: 'white',
+                      padding: '4px 12px',
+                      borderRadius: '6px',
+                      fontSize: '14px',
+                      fontWeight: 600
+                    }}>
+                      גרסה 1.9.3
+                    </span>
+                    <time dateTime="2026-02-04" style={{ color: '#64748b', fontSize: '14px' }}>
+                      4 בפברואר 2026
+                    </time>
+                  </div>
+                  <div style={{ fontSize: '20px' }}>
+                    {expandedVersions['1.9.3'] ? '▴' : '▾'}
+                  </div>
+                </div>
+                <h3 style={{
+                  fontSize: '16px',
+                  fontWeight: 600,
+                  margin: '8px 0 0 0',
+                  color: '#1e293b',
+                  lineHeight: 1.4
+                }}>
+                  ✨ שיפורים בתהליך הקליטה
+                </h3>
+              </header>
+
+              {expandedVersions['1.9.3'] && (
+                <div style={{
+                  padding: '0 16px',
+                  borderRight: '3px solid #5B5BD6',
+                  marginRight: '16px'
+                }}>
+                  <p style={{ margin: '0 0 12px', display: 'flex', alignItems: 'start', gap: '8px' }}>
+                    <span style={{ color: '#5B5BD6', fontSize: '18px', marginTop: '2px' }}>✨</span>
+                    <span>ניתן כעת להוסיף הערות אישיות בעת אישור קליטת תלמיד חדש - ההערות נשמרות בפרופיל התלמיד יחד עם התאריך</span>
+                  </p>
+                </div>
+              )}
+            </article>
+          </li>
 
           {/* 1.9.2 - Bug Fix */}
           <li dir="rtl" style={{ marginBottom: 16, textAlign: 'right' }}>

--- a/src/components/ChangelogModal.jsx
+++ b/src/components/ChangelogModal.jsx
@@ -121,13 +121,19 @@ export default function ChangelogModal({ open, onClose }) {
                       4 בפברואר 2026
                     </time>
                   </div>
-                  <div style={{ fontSize: '20px' }}>
-                    {expandedVersions['1.9.3'] ? '▴' : '▾'}
-                  </div>
+                  <span style={{
+                    fontSize: '20px',
+                    color: '#64748b',
+                    transition: 'transform 0.2s ease',
+                    transform: expandedVersions['1.9.3'] ? 'rotate(180deg)' : 'rotate(0deg)',
+                    display: 'inline-block'
+                  }}>
+                    ▼
+                  </span>
                 </div>
                 <h3 style={{
-                  fontSize: '16px',
-                  fontWeight: 600,
+                  fontWeight: 700,
+                  fontSize: 18,
                   margin: '8px 0 0 0',
                   color: '#1e293b',
                   lineHeight: 1.4
@@ -137,16 +143,17 @@ export default function ChangelogModal({ open, onClose }) {
               </header>
 
               {expandedVersions['1.9.3'] && (
-                <div style={{
-                  padding: '0 16px',
-                  borderRight: '3px solid #5B5BD6',
-                  marginRight: '16px'
+              <section style={{ paddingRight: '16px' }}>
+                <ul style={{
+                  listStyleType: 'disc',
+                  paddingRight: '20px',
+                  marginBottom: '16px',
+                  color: '#475569',
+                  lineHeight: 1.8
                 }}>
-                  <p style={{ margin: '0 0 12px', display: 'flex', alignItems: 'start', gap: '8px' }}>
-                    <span style={{ color: '#5B5BD6', fontSize: '18px', marginTop: '2px' }}>✨</span>
-                    <span>ניתן כעת להוסיף הערות אישיות בעת אישור קליטת תלמיד חדש - ההערות נשמרות בפרופיל התלמיד יחד עם התאריך</span>
-                  </p>
-                </div>
+                  <li>ניתן כעת להוסיף הערות אישיות בעת אישור קליטת תלמיד חדש - ההערות נשמרות בפרופיל התלמיד יחד עם התאריך.</li>
+                </ul>
+              </section>
               )}
             </article>
           </li>

--- a/src/features/dashboard/components/IntakeReviewQueue.jsx
+++ b/src/features/dashboard/components/IntakeReviewQueue.jsx
@@ -216,6 +216,7 @@ export default function IntakeReviewQueue() {
   const [expandedAnswers, setExpandedAnswers] = useState(() => new Set());
   const [confirmingStudentId, setConfirmingStudentId] = useState('');
   const [agreementChecked, setAgreementChecked] = useState(false);
+  const [approvalNotes, setApprovalNotes] = useState('');
   const [instructorFilterId, setInstructorFilterId] = useState('');
   const [retryToken, setRetryToken] = useState(0);
   const [assignmentFilter, setAssignmentFilter] = useState('all');
@@ -355,7 +356,7 @@ export default function IntakeReviewQueue() {
     setRetryToken((value) => value + 1);
   };
 
-  const handleApprove = async (studentId, agreement) => {
+  const handleApprove = async (studentId, agreement, notes) => {
     if (!session || !activeOrgId) {
       return;
     }
@@ -375,6 +376,7 @@ export default function IntakeReviewQueue() {
           org_id: activeOrgId,
           student_id: studentId,
           agreement,
+          approval_notes: notes,
         },
       });
       setPendingStudents((prev) => prev.filter((student) => student.id !== studentId));
@@ -439,12 +441,14 @@ export default function IntakeReviewQueue() {
   const openConfirmDialog = (studentId) => {
     setConfirmingStudentId(studentId);
     setAgreementChecked(false);
+    setApprovalNotes('');
   };
 
   const closeConfirmDialog = (open) => {
     if (!open) {
       setConfirmingStudentId('');
       setAgreementChecked(false);
+      setApprovalNotes('');
     }
   };
 
@@ -459,9 +463,10 @@ export default function IntakeReviewQueue() {
       acknowledged: true,
       acknowledged_at: new Date().toISOString(),
       statement: APPROVAL_AGREEMENT_TEXT,
-    });
+    }, approvalNotes);
     setConfirmingStudentId('');
     setAgreementChecked(false);
+    setApprovalNotes('');
   };
 
   const instructorMap = useMemo(() => {
@@ -1291,6 +1296,19 @@ export default function IntakeReviewQueue() {
             <Label htmlFor="intake-approval-agreement" className="text-sm text-slate-700">
               {APPROVAL_AGREEMENT_TEXT}
             </Label>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="intake-approval-notes">הערות קליטה (אופציונלי)</Label>
+            <Textarea
+              id="intake-approval-notes"
+              value={approvalNotes}
+              onChange={(event) => setApprovalNotes(event.target.value)}
+              rows={4}
+              placeholder="הוסיפו הערות מהשיחה עם ההורים/אפוטרופוס/תלמיד"
+            />
+            <p className="text-xs text-slate-500">
+              אם תוסיפו הערות, הן יישמרו בתחילת ההערות הקיימות של התלמיד.
+            </p>
           </div>
           <AlertDialogFooter>
             <AlertDialogCancel>בטל</AlertDialogCancel>

--- a/src/features/dashboard/components/IntakeReviewQueue.jsx
+++ b/src/features/dashboard/components/IntakeReviewQueue.jsx
@@ -356,7 +356,7 @@ export default function IntakeReviewQueue() {
     setRetryToken((value) => value + 1);
   };
 
-  const handleApprove = async (studentId, agreement, notes) => {
+  const handleApprove = async (studentId, agreement, notes, approvalDate) => {
     if (!session || !activeOrgId) {
       return;
     }
@@ -377,6 +377,7 @@ export default function IntakeReviewQueue() {
           student_id: studentId,
           agreement,
           approval_notes: notes,
+          approval_date: approvalDate,
         },
       });
       setPendingStudents((prev) => prev.filter((student) => student.id !== studentId));
@@ -459,11 +460,13 @@ export default function IntakeReviewQueue() {
     if (!confirmingStudentId || !agreementChecked) {
       return;
     }
+    const now = new Date();
+    const localDateStr = now.toLocaleDateString('he-IL', { day: '2-digit', month: '2-digit', year: 'numeric' });
     await handleApprove(confirmingStudentId, {
       acknowledged: true,
-      acknowledged_at: new Date().toISOString(),
+      acknowledged_at: now.toISOString(),
       statement: APPROVAL_AGREEMENT_TEXT,
-    }, approvalNotes);
+    }, approvalNotes, localDateStr);
     setConfirmingStudentId('');
     setAgreementChecked(false);
     setApprovalNotes('');


### PR DESCRIPTION
Allow approvers to attach optional intake notes when approving a student intake. API: add buildIntakeNotesBlock formatting (with separator and label "הערות קליטה"), select existing Students.notes, prepend the formatted notes to existing notes when present, and include notes in the update payload. Frontend: add approvalNotes state, Textarea in the intake approval dialog, pass approval_notes to /api/intake/approve, and reset state on open/close. Documentation: AGENTS.md updated to describe the new optional approval notes behavior.